### PR TITLE
Docs/readme tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 Clone this repository, giving the name of the new module - prefixed with the word `cartridge-`. This will be the name of the folder the source is cloned into.
 ```sh
-git https://github.com/cartridge/base-module.git --depth=1 cartridge-my-module
+git clone https://github.com/cartridge/base-module.git --depth=1 cartridge-my-module
 ```
 
 Update the git origin to match your new repository eg:

--- a/README.md
+++ b/README.md
@@ -5,21 +5,15 @@
 ## Using for a new module
 [Create a new empty repository](https://github.com/new) for your expansion pack.
 
-Clone this repository
+Clone this repository, giving the name of the new module. This should be prefixed with the word `cartridge-`
 ```sh
-git clone git@github.com:cartridge/base-module.git
+git https://github.com/cartridge/base-module.git --depth=1 cartridge-my-module
 ```
 
-Rename the `base-module` directory for your new module eg:
-```sh
-mv base-module cartridge-my-module
-```
-
-Update the git origin to match your new repository eg:
+If you haven't already, create a new repository for your module and update the git origin to match eg.
 
 ```sh
-cd cartridge-my-module
-git remote set-url origin git@github.com:cartridge/test.git
+git remote set-url origin https://github.com/cartridge/cartridge-my-module.git
 git remote -v
 ```
 
@@ -34,7 +28,7 @@ And do some coding!
 ## Development on the base module
 Clone repository
 ```sh
-git@github.com:cartridge/base-module.git
+git clone https://github.com/cartridge/base-module.git
 ```
 
 Install dependencies

--- a/README.md
+++ b/README.md
@@ -5,14 +5,15 @@
 ## Using for a new module
 [Create a new empty repository](https://github.com/new) for your expansion pack.
 
-Clone this repository, giving the name of the new module. This should be prefixed with the word `cartridge-`
+Clone this repository, giving the name of the new module. This should be prefixed with the word `cartridge-`. This will be the name of the folder the source is cloned into.
 ```sh
 git https://github.com/cartridge/base-module.git --depth=1 cartridge-my-module
 ```
 
-If you haven't already, create a new repository for your module and update the git origin to match eg.
+Update the git origin to match your new repository eg:
 
 ```sh
+cd cartridge-my-module
 git remote set-url origin https://github.com/cartridge/cartridge-my-module.git
 git remote -v
 ```

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ## Using for a new module
 [Create a new empty repository](https://github.com/new) for your expansion pack.
 
-Clone this repository, giving the name of the new module. This should be prefixed with the word `cartridge-`. This will be the name of the folder the source is cloned into.
+Clone this repository, giving the name of the new module - prefixed with the word `cartridge-`. This will be the name of the folder the source is cloned into.
 ```sh
 git https://github.com/cartridge/base-module.git --depth=1 cartridge-my-module
 ```


### PR DESCRIPTION
## Tweaks to README
> A few minor changes after following the instructions of the initial README

Changed the initial git clone command:
* Change to HTTP. SSH it awesome, but it requires setup on the local machine and HTTPS lowers the barrier of entry for people.
* Added in `depth=1` to only pull down the last commit in the history.
* Explicitly name the clone folder name. This is for if you have the base-module cloned already (for development purposes)

## Status
- [x] Ready for review
- [ ] In development

## Todos
> Make sure you’ve completed these:

- [x] Does this feature run on all supported platforms?
- [x] Are there tests around this feature?
- [x] Is there documentation for this feature?
